### PR TITLE
Was getting a str type in message on my slack export

### DIFF
--- a/find_message.py
+++ b/find_message.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
     for chan,messages in channels.items():
         for message in messages:
             # Weirdly, slack doesn't reference the channel in the message itself
+            if type(message) is not dict: continue
             message["channel"] = chan
             if args.reactions:
                 if 'reactions' in message:


### PR DESCRIPTION
./find_message.py ../Slack ginger
Reading in slack data dump
Processing Messages
Traceback (most recent call last):
  File "/home/kirk/Documents/Brewing/Libation/slack-export-tools/./find_message.py", line 57, in <module>
    message["channel"] = chan
TypeError: 'str' object does not support item assignment

